### PR TITLE
Save the docs as a build artifact

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,9 @@ documentation:
                 versioninfo()'
     - julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'
     - julia --color=yes --project=docs/ docs/make.jl
+  artifacts:
+    paths:
+      - docs/build
   only:
   - master
   - tags


### PR DESCRIPTION
This allows for looking through rendered versions of the docs in PRs.