### PR TITLE
Slight modifications to the DCP section.

### DIFF
--- a/docs/src/model_components/dosing_control.md
+++ b/docs/src/model_components/dosing_control.md
@@ -1,6 +1,6 @@
 # Dosing Control Parameters (DCP)
 
-The `pre` part of a `PumasModel` allows for specifying special preprocessed
+The `pre` part of a `PumasModel` allows for specifying special pre-processed
 parameters known as the Dosing Control Parameters (DCP). Unlike standard parameters
 which are for use in the proceeding blocks, the DCP are used to modify the
 internal event handling of the Pumas. The DCP are defined as follows:
@@ -23,12 +23,26 @@ If a DCP is defined as a scalar, then it applies to all doses. For example,
 if a `pre` block contains the definition:
 
 ```julia
-lags = θ
+@pre begin
+	lags = θ
+end
 ```
 
-and θ is a scalar, then every dose will be lagged by the parameter θ. Likewise,
-if a DCP is defined as a collection, then the value of the collection corresponding
-to the `cmt` of the dose specifies the DCP. For example:
+and θ is a scalar, then every dose will be lagged by the parameter θ. If there are
+several dynamic variables (compartments) they can have individual lags associated
+with dosing into them like the following:
+
+```julia
+@pre begin
+    lags = (Depot1=θ, Depot2=0.5)
+end
+```
+
+where the lag of dosing into `Depot1` is controlled by `θ` and the lag of dosing
+into `Depot2` is fixed at `0.5`. Omitting dynamic variables in this way of specifying
+DCPs implicitly sets the value of the missing variables to the default value as
+specified at the top. Likewise, if a DCP is defined as a collection, then the
+value of the collection corresponding to the `cmt`-index of the dose specifies the DCP. For example:
 
 ```julia
 lags = [2,0]
@@ -36,6 +50,3 @@ lags = [2,0]
 
 implies that any dose into `cmt=1` will have a lag of 2, while any dose into
 `cmt=2` will have a lag of 0.
-
-**Note: the ability to specify a DCP by a NamedTuple with names matching the
-dynamical parameters is in development**


### PR DESCRIPTION
Remove an outdated comment on NamedTuples and add a NamedTuple example before the vector example.