### PR TITLE
Changed "events = ev1" to "events = regimen"

### DIFF
--- a/docs/src/tutorials/introduction.md
+++ b/docs/src/tutorials/introduction.md
@@ -102,7 +102,7 @@ turnover_params = (tvcl = 1.5,
 
 ```julia
 regimen = DosageRegimen(150, rate = 10, cmt = 1)
-pop = Population(map(i -> Subject(id = i,events = ev1), 1:10))
+pop = Population(map(i -> Subject(id = i,events = regimen), 1:10))
 ```
 
 ```julia


### PR DESCRIPTION
I believe the events argument was inadvertently changed to "ev1." Previous versions used "evs=regimen" in the Population call.